### PR TITLE
chore: expand commit message body max length

### DIFF
--- a/.github/workflows/.commitlintrc.js
+++ b/.github/workflows/.commitlintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
     extends: [
         '@commitlint/config-conventional'
-    ]
+    ],
+    rules: {
+        'body-max-line-length': [2, 'always', 120]
+    }
 };


### PR DESCRIPTION
closes #52 